### PR TITLE
add I2C_BUS variable to support using another i2c-bus device

### DIFF
--- a/Software/wittypi/daemon.sh
+++ b/Software/wittypi/daemon.sh
@@ -57,11 +57,11 @@ done
 if [ $has_mc == 1 ] ; then
 
   # log the I2C_CONF_RTC_OFFSET
-  offset=$(i2c_read 0x01 $I2C_MC_ADDRESS $I2C_CONF_RTC_OFFSET)
+  offset=$(i2c_read ${I2C_BUS} $I2C_MC_ADDRESS $I2C_CONF_RTC_OFFSET)
   log "RTC offset register has value $offset"
 
   # make sure register I2C_RTC_CTRL1 is 0
-  i2c_write 0x01 $I2C_MC_ADDRESS $I2C_RTC_CTRL1 0
+  i2c_write ${I2C_BUS} $I2C_MC_ADDRESS $I2C_RTC_CTRL1 0
   
   # synchronize system and RTC time
   if [ $(rtc_has_bad_time) == 1 ]; then
@@ -73,15 +73,15 @@ if [ $has_mc == 1 ] ; then
   fi
 
   # check if system was shut down because of low-voltage
-  recovery=$(i2c_read 0x01 $I2C_MC_ADDRESS $I2C_LV_SHUTDOWN)
+  recovery=$(i2c_read ${I2C_BUS} $I2C_MC_ADDRESS $I2C_LV_SHUTDOWN)
   if [ $recovery == '0x01' ]; then
     log 'System was previously shut down because of low-voltage.'
   fi
   # print out firmware ID
-  firmwareID=$(i2c_read 0x01 $I2C_MC_ADDRESS $I2C_ID)
+  firmwareID=$(i2c_read ${I2C_BUS} $I2C_MC_ADDRESS $I2C_ID)
   log "Firmware ID: $firmwareID"
   # print out firmware revision
-  firmwareRev=$(i2c_read 0x01 $I2C_MC_ADDRESS $I2C_FW_REVISION)
+  firmwareRev=$(i2c_read ${I2C_BUS} $I2C_MC_ADDRESS $I2C_FW_REVISION)
   log "Firmware Revison: $firmwareRev"
   # print out current voltages and current
   vout=$(get_output_voltage)
@@ -94,8 +94,8 @@ if [ $has_mc == 1 ] ; then
   fi
 
   # if temperature sensor thresholds are not set, set them now
-  btp=$(i2c_read 0x01 $I2C_MC_ADDRESS $I2C_CONF_BELOW_TEMP_POINT)
-  otp=$(i2c_read 0x01 $I2C_MC_ADDRESS $I2C_CONF_OVER_TEMP_POINT)
+  btp=$(i2c_read ${I2C_BUS} $I2C_MC_ADDRESS $I2C_CONF_BELOW_TEMP_POINT)
+  otp=$(i2c_read ${I2C_BUS} $I2C_MC_ADDRESS $I2C_CONF_OVER_TEMP_POINT)
   if [ $btp == '0x00' ] && [ $otp == '0x00' ]; then
     i2cset -y 0x01 $I2C_MC_ADDRESS $I2C_LM75B_THYST 0x004b w
     i2cset -y 0x01 $I2C_MC_ADDRESS $I2C_LM75B_TOS 0x0050 w
@@ -104,8 +104,8 @@ fi
 
 # check and clear alarm flags
 if [ $has_mc == 1 ] ; then
-  flag1=$(i2c_read 0x01 $I2C_MC_ADDRESS $I2C_CONF_FLAG_ALARM1)
-  flag2=$(i2c_read 0x01 $I2C_MC_ADDRESS $I2C_CONF_FLAG_ALARM2)
+  flag1=$(i2c_read ${I2C_BUS} $I2C_MC_ADDRESS $I2C_CONF_FLAG_ALARM1)
+  flag2=$(i2c_read ${I2C_BUS} $I2C_MC_ADDRESS $I2C_CONF_FLAG_ALARM2)
   if [ "$flag1" == "1" ]; then
     # woke up by alarm 1 (startup)
     log 'System startup as scheduled.'
@@ -116,7 +116,7 @@ if [ $has_mc == 1 ] ; then
   fi
   clear_alarm_flags
 
-  reason=$(i2c_read 0x01 $I2C_MC_ADDRESS $I2C_ACTION_REASON)
+  reason=$(i2c_read ${I2C_BUS} $I2C_MC_ADDRESS $I2C_ACTION_REASON)
   if [ "$reason" == $REASON_ALARM1 ]; then
     log 'System starts up because scheduled startup is due.'
   elif [ "$reason" == $REASON_CLICK ]; then
@@ -197,7 +197,7 @@ log 'Pending for incoming shutdown command...'
 gpio -g wfi $HALT_PIN falling
 
 if [ $has_mc == 1 ] ; then
-  reason=$(i2c_read 0x01 $I2C_MC_ADDRESS $I2C_ACTION_REASON)
+  reason=$(i2c_read ${I2C_BUS} $I2C_MC_ADDRESS $I2C_ACTION_REASON)
   if [ "$reason" == $REASON_ALARM2 ]; then
     log 'Shutting down system because scheduled shutdown is due.'
   elif [ "$reason" == $REASON_CLICK ]; then

--- a/Software/wittypi/wittyPi.sh
+++ b/Software/wittypi/wittyPi.sh
@@ -171,7 +171,7 @@ configure_low_voltage_threshold()
       local ts=$(printf 'Low voltage threshold set to %.1fV!\n' $threshold)
       log "  $ts" && sleep 2
     elif (( $(awk "BEGIN {print ($threshold == 0)}") )); then
-      i2c_write 0x01 $I2C_MC_ADDRESS $I2C_CONF_LOW_VOLTAGE 0xFF
+      i2c_write ${I2C_BUS} $I2C_MC_ADDRESS $I2C_CONF_LOW_VOLTAGE 0xFF
       log 'Disabled low voltage threshold!' && sleep 2
     else
       echo 'Please input from 3.0 to 4.2 ...' && sleep 2
@@ -184,7 +184,7 @@ configure_low_voltage_threshold()
       local ts=$(printf 'Low voltage threshold set to %.1fV!\n' $threshold)
       log "  $ts" && sleep 2
     elif (( $(awk "BEGIN {print ($threshold == 0)}") )); then
-      i2c_write 0x01 $I2C_MC_ADDRESS $I2C_CONF_LOW_VOLTAGE 0xFF
+      i2c_write ${I2C_BUS} $I2C_MC_ADDRESS $I2C_CONF_LOW_VOLTAGE 0xFF
       log 'Disabled low voltage threshold!' && sleep 2
     else
       echo 'Please input from 2.0 to 25.0 ...' && sleep 2
@@ -198,11 +198,11 @@ configure_recovery_voltage_threshold()
     # Witty Pi 4 L3V7
     read -p 'Turn on RPi when USB 5V is connected (0=No, 1=Yes): ' action
     if [ "$action" == '0' ]; then
-      i2c_write 0x01 $I2C_MC_ADDRESS $I2C_CONF_RECOVERY_VOLTAGE 0
+      i2c_write ${I2C_BUS} $I2C_MC_ADDRESS $I2C_CONF_RECOVERY_VOLTAGE 0
       echo '  Will do nothing when USB 5V is connected.'
       sleep 2
     elif [ "$action" == '1' ]; then
-      i2c_write 0x01 $I2C_MC_ADDRESS $I2C_CONF_RECOVERY_VOLTAGE 1
+      i2c_write ${I2C_BUS} $I2C_MC_ADDRESS $I2C_CONF_RECOVERY_VOLTAGE 1
       echo '  Will turn on RPi when USB 5V is connected.'
       sleep 2
     else
@@ -217,7 +217,7 @@ configure_recovery_voltage_threshold()
       local ts=$(printf 'Recovery voltage threshold set to %.1fV!\n' $threshold)
       log "  $ts" && sleep 2
     elif (( $(awk "BEGIN {print ($threshold == 0)}") )); then
-      i2c_write 0x01 $I2C_MC_ADDRESS $I2C_CONF_RECOVERY_VOLTAGE 0xFF
+      i2c_write ${I2C_BUS} $I2C_MC_ADDRESS $I2C_CONF_RECOVERY_VOLTAGE 0xFF
       log 'Disabled recovery voltage threshold!' && sleep 2
     else
       echo 'Please input from 2.0 to 25.0 ...' && sleep 2
@@ -271,8 +271,8 @@ set_default_state()
 {
   read -p 'Input new default state (1 or 0: 1=ON, 0=OFF): ' state
   case $state in
-    0) i2c_write 0x01 $I2C_MC_ADDRESS $I2C_CONF_DEFAULT_ON 0x00 && log 'Set to "Default OFF"!' && sleep 2;;
-    1) i2c_write 0x01 $I2C_MC_ADDRESS $I2C_CONF_DEFAULT_ON 0x01 && log 'Set to "Default ON"!' && sleep 2;;
+    0) i2c_write ${I2C_BUS} $I2C_MC_ADDRESS $I2C_CONF_DEFAULT_ON 0x00 && log 'Set to "Default OFF"!' && sleep 2;;
+    1) i2c_write ${I2C_BUS} $I2C_MC_ADDRESS $I2C_CONF_DEFAULT_ON 0x01 && log 'Set to "Default ON"!' && sleep 2;;
     *) echo 'Please input 1 or 0 ...' && sleep 2;;
   esac
 }
@@ -286,7 +286,7 @@ set_power_cut_delay()
   read -p "Input new delay (0.0~$maxVal: value in seconds): " delay
   if (( $(awk "BEGIN {print ($delay >= 0 && $delay <= $maxVal)}") )); then
     local d=$(calc $delay*10)
-    i2c_write 0x01 $I2C_MC_ADDRESS $I2C_CONF_POWER_CUT_DELAY ${d%.*}
+    i2c_write ${I2C_BUS} $I2C_MC_ADDRESS $I2C_CONF_POWER_CUT_DELAY ${d%.*}
     log "Power cut delay set to $delay seconds!" && sleep 2
   else
     echo "Please input from 0.0 to $maxVal ..." && sleep 2
@@ -297,7 +297,7 @@ set_pulsing_interval()
 {
 	read -p 'Input new interval (value in seconds, 1~20): ' interval
 	if [ $interval -ge 1 ] && [ $interval -le 20 ]; then
-	  i2c_write 0x01 $I2C_MC_ADDRESS $I2C_CONF_PULSE_INTERVAL $interval
+	  i2c_write ${I2C_BUS} $I2C_MC_ADDRESS $I2C_CONF_PULSE_INTERVAL $interval
 	  log "Pulsing interval set to $interval seconds!" && sleep 2
 	else
 	  echo 'Please input from 1 to 20' && sleep 2
@@ -308,7 +308,7 @@ set_white_led_duration()
 {
 	read -p 'Input new duration for white LED (value in milliseconds, 0~254): ' duration
 	if [ $duration -ge 0 ] && [ $duration -le 254 ]; then
-		i2c_write 0x01 $I2C_MC_ADDRESS $I2C_CONF_BLINK_LED $duration
+		i2c_write ${I2C_BUS} $I2C_MC_ADDRESS $I2C_CONF_BLINK_LED $duration
 		log "White LED duration set to $duration!" && sleep 2
 	else
 	  echo 'Please input from 0 to 254' && sleep 2
@@ -319,7 +319,7 @@ set_dummy_load_duration()
 {
 	read -p 'Input new duration for dummy load (value in milliseconds, 0~254): ' duration
 	if [ $duration -ge 0 ] && [ $duration -le 254 ]; then
-		i2c_write 0x01 $I2C_MC_ADDRESS $I2C_CONF_DUMMY_LOAD $duration
+		i2c_write ${I2C_BUS} $I2C_MC_ADDRESS $I2C_CONF_DUMMY_LOAD $duration
 		log "Dummy load duration set to $duration!" && sleep 2
 	else
 	  echo 'Please input from 0 to 254' && sleep 2
@@ -334,7 +334,7 @@ set_vin_adjustment()
     if (( $(awk "BEGIN {print ($adj < 0)}") )); then
     	adj=$((255+$adj))
     fi
-    i2c_write 0x01 $I2C_MC_ADDRESS $I2C_CONF_ADJ_VIN ${adj%.*}
+    i2c_write ${I2C_BUS} $I2C_MC_ADDRESS $I2C_CONF_ADJ_VIN ${adj%.*}
     local setting=$(printf 'Vin adjustment set to %.2fV!\n' $vinAdj)
     log "$setting" && sleep 2
   else
@@ -350,7 +350,7 @@ set_vout_adjustment()
     if (( $(awk "BEGIN {print ($adj < 0)}") )); then
     	adj=$((255+$adj))
     fi
-    i2c_write 0x01 $I2C_MC_ADDRESS $I2C_CONF_ADJ_VOUT ${adj%.*}
+    i2c_write ${I2C_BUS} $I2C_MC_ADDRESS $I2C_CONF_ADJ_VOUT ${adj%.*}
     local setting=$(printf 'Vout adjustment set to %.2fV!\n' $voutAdj)
     log "$setting" && sleep 2
   else
@@ -366,7 +366,7 @@ set_iout_adjustment()
     if (( $(awk "BEGIN {print ($adj < 0)}") )); then
     	adj=$((255+$adj))
     fi
-    i2c_write 0x01 $I2C_MC_ADDRESS $I2C_CONF_ADJ_IOUT ${adj%.*}
+    i2c_write ${I2C_BUS} $I2C_MC_ADDRESS $I2C_CONF_ADJ_IOUT ${adj%.*}
     local setting=$(printf 'Iout adjustment set to %.2fA!\n' $ioutAdj)
     log "$setting" && sleep 2
   else
@@ -379,7 +379,7 @@ set_default_on_delay()
   if [ $(($firmwareRev)) -ge 2 ]; then
     read -p 'Wait how many seconds before Auto-ON (0~10): ' delay
   	if [ $delay -ge 0 ] && [ $delay -le 10 ]; then
-  	  i2c_write 0x01 $I2C_MC_ADDRESS $I2C_CONF_DEFAULT_ON_DELAY $delay
+  	  i2c_write ${I2C_BUS} $I2C_MC_ADDRESS $I2C_CONF_DEFAULT_ON_DELAY $delay
   	  log "Default ON delay set to $delay seconds!" && sleep 2
   	else
   	  echo 'Please input from 0 to 10' && sleep 2

--- a/Software/wittypi/wittyPi.sh
+++ b/Software/wittypi/wittyPi.sh
@@ -46,8 +46,8 @@ if ! hash gpio 2>/dev/null; then
 fi
 
 if [ $(is_mc_connected) -eq 1 ]; then
-  firmwareID=$(i2c_read 0x01 $I2C_MC_ADDRESS $I2C_ID)
-  firmwareRev=$(i2c_read 0x01 $I2C_MC_ADDRESS $I2C_FW_REVISION)
+  firmwareID=$(i2c_read ${I2C_BUS} $I2C_MC_ADDRESS $I2C_ID)
+  firmwareRev=$(i2c_read ${I2C_BUS} $I2C_MC_ADDRESS $I2C_FW_REVISION)
 fi
 
 # interactive actions
@@ -393,28 +393,28 @@ other_settings()
 {
   echo 'Here you can set:'
   echo -n '  [1] Default state when powered'
-  local ds=$(i2c_read 0x01 $I2C_MC_ADDRESS $I2C_CONF_DEFAULT_ON)
+  local ds=$(i2c_read ${I2C_BUS} $I2C_MC_ADDRESS $I2C_CONF_DEFAULT_ON)
   if [[ $ds -eq 0 ]]; then
     echo ' [default OFF]'
 	else
     echo ' [default ON]'
   fi
   echo -n '  [2] Power cut delay after shutdown'
-  local pcd=$(i2c_read 0x01 $I2C_MC_ADDRESS $I2C_CONF_POWER_CUT_DELAY)
+  local pcd=$(i2c_read ${I2C_BUS} $I2C_MC_ADDRESS $I2C_CONF_POWER_CUT_DELAY)
   pcd=$(calc $(($pcd))/10)
   printf ' [%.1f Seconds]\n' "$pcd"
   echo -n '  [3] Pulsing interval during sleep'
-  local pi=$(i2c_read 0x01 $I2C_MC_ADDRESS $I2C_CONF_PULSE_INTERVAL)
+  local pi=$(i2c_read ${I2C_BUS} $I2C_MC_ADDRESS $I2C_CONF_PULSE_INTERVAL)
   pi=$(hex2dec $pi)
   echo " [$pi Seconds]"
   echo -n '  [4] White LED duration'
-  local led=$(i2c_read 0x01 $I2C_MC_ADDRESS $I2C_CONF_BLINK_LED)
+  local led=$(i2c_read ${I2C_BUS} $I2C_MC_ADDRESS $I2C_CONF_BLINK_LED)
   printf ' [%d]\n' "$led"
   echo -n '  [5] Dummy load duration'
-  local dload=$(i2c_read 0x01 $I2C_MC_ADDRESS $I2C_CONF_DUMMY_LOAD)
+  local dload=$(i2c_read ${I2C_BUS} $I2C_MC_ADDRESS $I2C_CONF_DUMMY_LOAD)
   printf ' [%d]\n' "$dload"
   echo -n '  [6] Vin adjustment'
-  local vinAdj=$(i2c_read 0x01 $I2C_MC_ADDRESS $I2C_CONF_ADJ_VIN)
+  local vinAdj=$(i2c_read ${I2C_BUS} $I2C_MC_ADDRESS $I2C_CONF_ADJ_VIN)
   if [[ $vinAdj -gt 127 ]]; then
   	vinAdj=$(calc $(($vinAdj-255))/100)
  	else
@@ -422,7 +422,7 @@ other_settings()
   fi
   printf ' [%.2fV]\n' "$vinAdj"
   echo -n '  [7] Vout adjustment'
-  local voutAdj=$(i2c_read 0x01 $I2C_MC_ADDRESS $I2C_CONF_ADJ_VOUT)
+  local voutAdj=$(i2c_read ${I2C_BUS} $I2C_MC_ADDRESS $I2C_CONF_ADJ_VOUT)
   if [[ $voutAdj -gt 127 ]]; then
   	voutAdj=$(calc $(($voutAdj-255))/100)
  	else
@@ -430,7 +430,7 @@ other_settings()
   fi
   printf ' [%.2fV]\n' "$voutAdj"
   echo -n '  [8] Iout adjustment'
-  local ioutAdj=$(i2c_read 0x01 $I2C_MC_ADDRESS $I2C_CONF_ADJ_IOUT)
+  local ioutAdj=$(i2c_read ${I2C_BUS} $I2C_MC_ADDRESS $I2C_CONF_ADJ_IOUT)
   if [[ $ioutAdj -gt 127 ]]; then
   	ioutAdj=$(calc $(($ioutAdj-255))/100)
  	else
@@ -440,7 +440,7 @@ other_settings()
   local optionCount=8;
   if [ $(($firmwareRev)) -ge 2 ]; then
     echo -n '  [9] Default ON delay'
-    local dod=$(i2c_read 0x01 $I2C_MC_ADDRESS $I2C_CONF_DEFAULT_ON_DELAY)
+    local dod=$(i2c_read ${I2C_BUS} $I2C_MC_ADDRESS $I2C_CONF_DEFAULT_ON_DELAY)
     dod=$(hex2dec $dod)
     echo " [$dod Seconds]"
     optionCount=9;
@@ -628,7 +628,7 @@ while true; do
   fi
   if [ $(($firmwareID)) -eq 55 ]; then
     echo -n '  8. Auto-On when USB 5V is connected'
-    recV=$(i2c_read 0x01 $I2C_MC_ADDRESS $I2C_CONF_RECOVERY_VOLTAGE)
+    recV=$(i2c_read ${I2C_BUS} $I2C_MC_ADDRESS $I2C_CONF_RECOVERY_VOLTAGE)
     if [ $(($recV)) -gt 0 ]; then
       echo "  [Yes]";
     else


### PR DESCRIPTION
This MR adds a variable I2C_BUS which allows to change the i2c bus that is used by the scripts

on OrangePi Zero the i2c-0 bus is used