### PR TITLE
Introduce RESET keyword for schedule.wpi

### DIFF
--- a/Software/wittypi/runScript.sh
+++ b/Software/wittypi/runScript.sh
@@ -90,6 +90,7 @@ setup_on_state()
 }
 
 if [ -f $schedule_file ]; then
+  reset=0
   begin=0
   end=0
   count=0
@@ -99,7 +100,9 @@ if [ -f $schedule_file ]; then
       line=${line:0:$cpos-1}
     fi
     line=$(trim "$line")
-    if [[ $line == BEGIN* ]]; then
+    if [[ $line == RESET* ]]; then
+      reset=1
+    elif [[ $line == BEGIN* ]]; then
       begin=$(extract_timestamp "$line")
     elif [[ $line == END* ]]; then
       end=$(extract_timestamp "$line")
@@ -115,6 +118,10 @@ if [ -f $schedule_file ]; then
     log 'I can not find the end time in the script...'
   elif [ $count == 0 ] ; then
     log 'I can not find any state defined in the script.'
+  elif [ $reset == 1 ] ; then
+    log 'Reseting scheduled startup/shutdown.'
+    clear_startup_time
+    clear_shutdown_time
   else
     if [ $((cur_time < begin)) == '1' ] ; then
       cur_time=$begin

--- a/Software/wittypi/runScript.sh
+++ b/Software/wittypi/runScript.sh
@@ -112,16 +112,17 @@ if [ -f $schedule_file ]; then
     fi
   done < $schedule_file
 
-  if [ $begin == 0 ] ; then
+  if [ $reset == 1 ] ; then
+    log 'Reseting scheduled startup/shutdown.'
+    clear_startup_time
+    clear_shutdown_time
+    delete_schedule_script
+  elif [ $begin == 0 ] ; then
     log 'I can not find the begin time in the script...'
   elif [ $end == 0 ] ; then
     log 'I can not find the end time in the script...'
   elif [ $count == 0 ] ; then
     log 'I can not find any state defined in the script.'
-  elif [ $reset == 1 ] ; then
-    log 'Reseting scheduled startup/shutdown.'
-    clear_startup_time
-    clear_shutdown_time
   else
     if [ $((cur_time < begin)) == '1' ] ; then
       cur_time=$begin

--- a/Software/wittypi/utilities.sh
+++ b/Software/wittypi/utilities.sh
@@ -698,3 +698,14 @@ check_sys_and_rtc_time()
     echo 'Please synchronize the time first.'
   fi
 }
+
+delete_schedule_script()
+{
+  log '  Deleting "schedule.wpi" file...' '-n'
+  if [ -f "schedule.wpi" ]; then
+    rm "schedule.wpi"
+    log ' done :-)'
+  else
+    log ' file does not exist'
+  fi
+}

--- a/Software/wittypi/wittyPi.sh
+++ b/Software/wittypi/wittyPi.sh
@@ -474,17 +474,6 @@ reset_shutdown_time()
   log ' done :-)'
 }
 
-delete_schedule_script()
-{
-  log '  Deleting "schedule.wpi" file...' '-n'
-  if [ -f "$my_dir/schedule.wpi" ]; then
-    rm "$my_dir/schedule.wpi"
-    log ' done :-)'
-  else
-    log ' file does not exist'
-  fi
-}
-
 reset_low_voltage_threshold()
 {
   log '  Clearing low voltage threshold...' '-n'


### PR DESCRIPTION
As described [here](https://www.uugear.com/forums/technial-support-discussion/witty-pi-4-l3v7-interupting-a-scheduler/#post-870) in the UUGear forum, I update the schedule.wpi file externally and set the new schedules by running `runScript.sh`.
In the moment one wants to unset the schedule, it doesn't work to just delete the schedule.wpi file as previously scheduled startup/shutdown don't get reset.
My proposal is to introduce a `RESET` keyword for the schedule.wpi file.